### PR TITLE
Add command to get dataset sizes, dataset retrieve

### DIFF
--- a/data_repo_cli/api/datasets.py
+++ b/data_repo_cli/api/datasets.py
@@ -2,31 +2,6 @@ from data_repo_cli.api.jobs import wait_for_job
 from data_repo_cli.common.gcloud_commands import get_current_gcloud_user
 
 from data_repo_cli.common.client_logger import logger
-from data_repo_cli.common.constants import SORT_FIELDS, SORT_DIRECTIONS
-from data_repo_cli.dispatch.datasets import dispatch_delete_dataset, dispatch_enumerate_datasets
-
-
-def setup_parser(subparsers):
-    delete_dataset_parser = subparsers.add_parser('delete-dataset', help='delete a dataset from TDR')
-    delete_dataset_parser.set_defaults(func=dispatch_delete_dataset)
-    delete_dataset_parser.add_argument('id', metavar='id', nargs=1, help='The ID of the dataset to delete')
-    delete_dataset_parser.add_argument('--add-steward', action='store_true', help='Add the currently-authed gcloud '
-                                                                                  'user as steward before deleting')
-
-    enumerate_datasets_parser = subparsers.add_parser('enumerate-datasets', help="Enumerate datasets")
-    enumerate_datasets_parser.set_defaults(func=dispatch_enumerate_datasets)
-    enumerate_datasets_parser.add_argument('-f', '--filter', type=str, default=None,
-                                           help="Case-insensitive match on the name or description")
-    enumerate_datasets_parser.add_argument('-s', '--sort', type=str, choices=SORT_FIELDS, default=None,
-                                           help="Field to sort results by")
-    enumerate_datasets_parser.add_argument('-d', '--direction', type=str, choices=SORT_DIRECTIONS, default=None,
-                                           help="The direction of sorting")
-    enumerate_datasets_parser.add_argument('-r', '--region', type=str, default=None,
-                                           help="Restrict results to the provided region")
-    enumerate_datasets_parser.add_argument('-o', '--offset', type=int, default=None,
-                                           help="Offset the results be the specified amount")
-    enumerate_datasets_parser.add_argument('-l', '--limit', type=int, default=None,
-                                           help="Limit the results to the specified number")
 
 
 def enumerate_datasets(clients, filter_string, sort, direction, offset, limit):
@@ -37,6 +12,10 @@ def enumerate_datasets(clients, filter_string, sort, direction, offset, limit):
         offset=offset,
         limit=limit
     )
+
+
+def retrieve_dataset(clients, dataset_id, include):
+    return clients.datasets_api.retrieve_dataset(dataset_id, include=include)
 
 
 def add_dataset_policy_member(clients, dataset_id, email, policy_name):

--- a/data_repo_cli/api/firestore.py
+++ b/data_repo_cli/api/firestore.py
@@ -1,0 +1,21 @@
+from data_repo_cli.api.datasets import retrieve_dataset
+from data_repo_cli.common.client_logger import logger
+
+from google.cloud import firestore
+from multiprocessing.pool import ThreadPool as Pool
+
+
+def calculate_dataset_file_size(clients, dataset_id, data_project):
+    if data_project is None:
+        dataset = retrieve_dataset(clients, dataset_id, ["ACCESS_INFORMATION"])
+        data_project = dataset.access_information.big_query.project_id
+        logger.info(f"Retrieved dataset, found data project: {data_project}")
+    else:
+        logger.info(f"Using supplied data-project: {data_project}")
+
+    firestore_client = firestore.Client(project=data_project)
+    file_collection = firestore_client.collection(f'{dataset_id}-files')
+    documents_list = file_collection.list_documents()
+    with Pool() as p:
+        bar = p.map(lambda d: d.get(['size']).get('size'), documents_list)
+    return sum(bar)

--- a/data_repo_cli/api/jobs.py
+++ b/data_repo_cli/api/jobs.py
@@ -1,17 +1,6 @@
 import time
 
 from data_repo_cli.common.client_logger import logger
-from data_repo_cli.dispatch.utils import dispatch_single_id_arg
-
-
-def setup_parser(subparsers):
-    job_status_parser = subparsers.add_parser('job-status', help='Get the status of a job')
-    job_status_parser.set_defaults(func=dispatch_single_id_arg(get_job_status))
-    job_status_parser.add_argument('id', metavar='id', nargs=1, help='The ID of the job to get status of')
-
-    job_result_parser = subparsers.add_parser('job-result', help='Get the result of a job')
-    job_result_parser.set_defaults(func=dispatch_single_id_arg(get_job_result))
-    job_result_parser.add_argument('id', metavar='id', nargs=1, help='The ID of the job to get result of')
 
 
 def get_job_status(clients, job_id):

--- a/data_repo_cli/api/snapshots.py
+++ b/data_repo_cli/api/snapshots.py
@@ -1,22 +1,6 @@
 from data_repo_cli.api.jobs import wait_for_job
 from data_repo_cli.common.gcloud_commands import get_current_gcloud_user
 from data_repo_cli.common.client_logger import logger
-from data_repo_cli.dispatch.utils import dispatch_single_id_arg
-from data_repo_cli.dispatch.snapshots import dispatch_delete_snapshot
-
-
-def setup_parser(subparsers):
-    delete_snapshot_parser = subparsers.add_parser('delete-snapshot', help='delete a snapshot from TDR')
-    delete_snapshot_parser.set_defaults(func=dispatch_delete_snapshot)
-    delete_snapshot_parser.add_argument('id', metavar='id', nargs=1, help='The ID of the snapshot to delete')
-    delete_snapshot_parser.add_argument('--add-steward', action='store_true',
-                                        help='Add the currently-authed gcloud user as steward before deleting')
-
-    snapshots_for_dataset_parser = subparsers.add_parser('snapshots-for-dataset',
-                                                         help='Get the snapshots belonging to a dataset')
-    snapshots_for_dataset_parser.set_defaults(func=dispatch_single_id_arg(get_snapshots_for_dataset))
-    snapshots_for_dataset_parser.add_argument('id', metavar='id', nargs=1,
-                                              help='The ID of the dataset to get the snapshots for')
 
 
 def add_snapshot_policy_member(clients, snapshot_id, email, policy_name):

--- a/data_repo_cli/app.py
+++ b/data_repo_cli/app.py
@@ -3,11 +3,13 @@ import json
 from data_repo_client import Configuration, ApiClient, ProfilesApi, DatasetsApi, SnapshotsApi, JobsApi
 import argparse
 
-from data_repo_cli.api.jobs import setup_parser as setup_job_parser
-from data_repo_cli.api.datasets import setup_parser as setup_dataset_parser
-from data_repo_cli.api.snapshots import setup_parser as setup_snapshot_parser
+from data_repo_cli.parser.jobs import setup_jobs_parser
+from data_repo_cli.parser.datasets import setup_datasets_parser
+from data_repo_cli.parser.snapshots import setup_snapshots_parser
+from data_repo_cli.parser.firestore import setup_firestore_parser
 from data_repo_cli.common.constants import ENVIRONMENTS
 from data_repo_cli.common.gcloud_commands import get_access_token
+
 
 class Clients:
     def __init__(self, host):
@@ -30,9 +32,10 @@ def setup_parser():
                         required=True)
     subparsers = parser.add_subparsers(help='The action to run')
 
-    setup_job_parser(subparsers)
-    setup_dataset_parser(subparsers)
-    setup_snapshot_parser(subparsers)
+    setup_jobs_parser(subparsers)
+    setup_datasets_parser(subparsers)
+    setup_snapshots_parser(subparsers)
+    setup_firestore_parser(subparsers)
     return parser
 
 

--- a/data_repo_cli/common/constants.py
+++ b/data_repo_cli/common/constants.py
@@ -8,3 +8,4 @@ ENVIRONMENTS = {
 SORT_FIELDS = ["name", "description", "created_date"]
 SORT_DIRECTIONS = ["asc", "desc"]
 
+RETRIEVE_DATASETS_INCLUDES = ["NONE", "SCHEMA", "ACCESS_INFORMATION", "PROFILE", "DATA_PROJECT", "STORAGE"]

--- a/data_repo_cli/dispatch/datasets.py
+++ b/data_repo_cli/dispatch/datasets.py
@@ -1,10 +1,16 @@
 import data_repo_cli.api.datasets as datasets
 
 
+def dispatch_retrieve_dataset(clients, args):
+    dataset_id = args.id[0]
+    include = args.include
+    return datasets.retrieve_dataset(clients, dataset_id, include)
+
+
 def dispatch_delete_dataset(clients, args):
     dataset_id = args.id[0]
     add_steward = args.add_steward
-    datasets.delete_dataset(clients, dataset_id, add_steward)
+    return datasets.delete_dataset(clients, dataset_id, add_steward)
 
 
 def dispatch_enumerate_datasets(clients, args):

--- a/data_repo_cli/dispatch/firestore.py
+++ b/data_repo_cli/dispatch/firestore.py
@@ -1,0 +1,7 @@
+from data_repo_cli.api.firestore import calculate_dataset_file_size
+
+
+def dispatch_calculate_dataset_file_size(clients, args):
+    dataset_id = args.id[0]
+    data_project = args.data_project
+    return calculate_dataset_file_size(clients, dataset_id, data_project)

--- a/data_repo_cli/parser/datasets.py
+++ b/data_repo_cli/parser/datasets.py
@@ -1,0 +1,32 @@
+from data_repo_cli.common.constants import SORT_FIELDS, SORT_DIRECTIONS, RETRIEVE_DATASETS_INCLUDES
+from data_repo_cli.dispatch.datasets import dispatch_delete_dataset, dispatch_enumerate_datasets, \
+    dispatch_retrieve_dataset
+
+
+def setup_datasets_parser(subparsers):
+    retrieve_dataset_parser = subparsers.add_parser('retrieve-dataset', help='Get a dataset from TDR')
+    retrieve_dataset_parser.set_defaults(func=dispatch_retrieve_dataset)
+    retrieve_dataset_parser.add_argument('id', nargs=1, help='The ID of the dataset to retrieve')
+    retrieve_dataset_parser.add_argument('-i', '--include', nargs='*', choices=RETRIEVE_DATASETS_INCLUDES,
+                                         help='Information about the dataset to include')
+
+    delete_dataset_parser = subparsers.add_parser('delete-dataset', help='delete a dataset from TDR')
+    delete_dataset_parser.set_defaults(func=dispatch_delete_dataset)
+    delete_dataset_parser.add_argument('id', metavar='id', nargs=1, help='The ID of the dataset to delete')
+    delete_dataset_parser.add_argument('--add-steward', action='store_true', help='Add the currently-authed gcloud '
+                                                                                  'user as steward before deleting')
+
+    enumerate_datasets_parser = subparsers.add_parser('enumerate-datasets', help="Enumerate datasets")
+    enumerate_datasets_parser.set_defaults(func=dispatch_enumerate_datasets)
+    enumerate_datasets_parser.add_argument('-f', '--filter', type=str, default=None,
+                                           help="Case-insensitive match on the name or description")
+    enumerate_datasets_parser.add_argument('-s', '--sort', type=str, choices=SORT_FIELDS, default=None,
+                                           help="Field to sort results by")
+    enumerate_datasets_parser.add_argument('-d', '--direction', type=str, choices=SORT_DIRECTIONS, default=None,
+                                           help="The direction of sorting")
+    enumerate_datasets_parser.add_argument('-r', '--region', type=str, default=None,
+                                           help="Restrict results to the provided region")
+    enumerate_datasets_parser.add_argument('-o', '--offset', type=int, default=None,
+                                           help="Offset the results be the specified amount")
+    enumerate_datasets_parser.add_argument('-l', '--limit', type=int, default=None,
+                                           help="Limit the results to the specified number")

--- a/data_repo_cli/parser/firestore.py
+++ b/data_repo_cli/parser/firestore.py
@@ -1,0 +1,11 @@
+from data_repo_cli.dispatch.firestore import dispatch_calculate_dataset_file_size
+
+
+def setup_firestore_parser(subparsers):
+    dataset_file_size_parser = subparsers.add_parser('dataset-file-size',
+                                                     help='Calculate the sum of file sizes in a dataset in bytes')
+    dataset_file_size_parser.set_defaults(func=dispatch_calculate_dataset_file_size)
+    dataset_file_size_parser.add_argument('id', metavar='id', nargs=1,
+                                          help="The ID of the dataset to calculate size for")
+    dataset_file_size_parser.add_argument('-d', '--data-project', default=None,
+                                          help='Use this data project instead of getting the data project from the API')

--- a/data_repo_cli/parser/jobs.py
+++ b/data_repo_cli/parser/jobs.py
@@ -1,0 +1,12 @@
+from data_repo_cli.api.jobs import get_job_result, get_job_status
+from data_repo_cli.dispatch.utils import dispatch_single_id_arg
+
+
+def setup_jobs_parser(subparsers):
+    job_status_parser = subparsers.add_parser('job-status', help='Get the status of a job')
+    job_status_parser.set_defaults(func=dispatch_single_id_arg(get_job_status))
+    job_status_parser.add_argument('id', metavar='id', nargs=1, help='The ID of the job to get status of')
+
+    job_result_parser = subparsers.add_parser('job-result', help='Get the result of a job')
+    job_result_parser.set_defaults(func=dispatch_single_id_arg(get_job_result))
+    job_result_parser.add_argument('id', metavar='id', nargs=1, help='The ID of the job to get result of')

--- a/data_repo_cli/parser/snapshots.py
+++ b/data_repo_cli/parser/snapshots.py
@@ -1,0 +1,17 @@
+from data_repo_cli.api.snapshots import get_snapshots_for_dataset
+from data_repo_cli.dispatch.snapshots import dispatch_delete_snapshot
+from data_repo_cli.dispatch.utils import dispatch_single_id_arg
+
+
+def setup_snapshots_parser(subparsers):
+    delete_snapshot_parser = subparsers.add_parser('delete-snapshot', help='delete a snapshot from TDR')
+    delete_snapshot_parser.set_defaults(func=dispatch_delete_snapshot)
+    delete_snapshot_parser.add_argument('id', metavar='id', nargs=1, help='The ID of the snapshot to delete')
+    delete_snapshot_parser.add_argument('--add-steward', action='store_true',
+                                        help='Add the currently-authed gcloud user as steward before deleting')
+
+    snapshots_for_dataset_parser = subparsers.add_parser('snapshots-for-dataset',
+                                                         help='Get the snapshots belonging to a dataset')
+    snapshots_for_dataset_parser.set_defaults(func=dispatch_single_id_arg(get_snapshots_for_dataset))
+    snapshots_for_dataset_parser.add_argument('id', metavar='id', nargs=1,
+                                              help='The ID of the dataset to get the snapshots for')

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,1 +1,2 @@
-data_repo_client==1.290.0
+data_repo_client==1.293.0
+firestore==0.0.8


### PR DESCRIPTION
Added a command to get a dataset's size based on information in firestore. This command requires read access to the dataset, to get the dataset's data-project. If an admin wants to get the size, without adding themselves as a user on the dataset, they can provide the data-project on the command-line use the `-d/--data-project` parameter.